### PR TITLE
Update bidseditor.py

### DIFF
--- a/bidscoin/bidseditor.py
+++ b/bidscoin/bidseditor.py
@@ -640,7 +640,7 @@ class Ui_MainWindow(MainWindow):
                 edit_button = QPushButton('Edit')
                 edit_button.setToolTip('Click to see more details and edit the BIDS output name')
                 edit_button.clicked.connect(self.handle_edit_button_clicked)
-                edit_button.setCheckable(True)
+                edit_button.setCheckable(False)
                 edit_button.setAutoExclusive(True)
                 if provenance.name and str(provenance)==self.has_edit_dialog_open:    # Highlight the previously opened item
                     edit_button.setChecked(True)


### PR DESCRIPTION
Fixes issue #59 bidscoin crash on mac osx. Focus on a selected button is very slow when using the mouse. Keyboard focus works fine.
